### PR TITLE
Separate exam files; counters; email restartable (skips completed netids)

### DIFF
--- a/library.tex
+++ b/library.tex
@@ -27,12 +27,12 @@
 \bigskip
 \noindent
 \begin{itemize}
-\item There are 3 problems worth points as shown in each question.
+\item There are \the\questioncountall{} problems worth points as shown in each question.
 \item You must not communicate with other students during this test.
 \item No books, notes, calculators, or electronic devices allowed.
 \item This is a 20 minute exam.
 \item Do not turn this page until instructed to.
-\item There are several different versions of this exam.
+\item There are several different versions of this exam (this is version \the\examnumber{}). Be sure to correctly mark the answer key below on your Scantron form.
 \end{itemize}
 
 \bigskip\bigskip
@@ -165,6 +165,18 @@ Evaluate $\displaystyle\int_{\pi/2}^{3\pi/2} x^2\sin x \, dx$.
 \answer $0$
 \answer $4\pi$
 \end{answers}
+\begin{solution}
+\end{solution}
+
+\zone
+\question{10}
+\variant
+Estimate the age of the Earth. Explain your answer.
+\begin{solution}
+\end{solution}
+
+\variant
+Explain why your answer to this question is likely to be incorrect.
 \begin{solution}
 \end{solution}
 

--- a/randexam
+++ b/randexam
@@ -8,7 +8,7 @@ import smtplib, email.mime.text, email.mime.multipart, email.mime.application, g
 import numpy as np
 
 #scipy only required to curve scores. Other functions can be safely run without this import
-import scipy.interpolate
+#import scipy.interpolate
 
 ######################################################################
 ######################################################################
@@ -18,6 +18,8 @@ TEST_NAME = "Exam Title, Spring 2071"
 FILENAME_PREFIX = "" # set to "midterm1_" or "final_" or similar
 FEEDBACK_DIRECTORY = "feedback"
 RAWSCAN_DIRECTORY = "" # optional directory containing per-student files <netid>.pdf
+
+MULTIPLE_EXAM_FILES = False
 
 MULTIPLE_ANSWERS_PER_QUESTION = False # can students bubble in more than one answer?
 SCORE_PER_ANSWERS = [0., 1., 1./2., 1./3., 0., 0.] # partial credit values vs. num bubbles
@@ -57,6 +59,7 @@ NETIDS_FILENAME = FILENAME_PREFIX + "netids.txt"
 
 # output filenames
 EXAMS_FILENAME = FILENAME_PREFIX + "exams.tex"
+EXAMS_DIRECTORY = "print"
 SOLUTIONS_FILENAME = FILENAME_PREFIX + "solutions.csv"
 FULL_SOLUTIONS_FILENAME = FILENAME_PREFIX + "full_solutions.tex"
 SPECS_FILENAME = FILENAME_PREFIX + "specs.csv"
@@ -113,7 +116,7 @@ def main():
         (K, Q, V, A) = generate_specs(library, N_e, N_A)
         check_key_distances(K)
         write_specs(SPECS_FILENAME, K, Q, V, A)
-        write_exams(EXAMS_FILENAME, library, K, Q, V, A, MINIMUM_EXAM_PAGES, ONE_PAGE_PER_QUESTION)
+        write_exams(EXAMS_DIRECTORY, EXAMS_FILENAME,MULTIPLE_EXAM_FILES, library, K, Q, V, A, MINIMUM_EXAM_PAGES, ONE_PAGE_PER_QUESTION)
         c = generate_solutions(Q, V, A, C)
         write_solutions(SOLUTIONS_FILENAME, K, c)
         write_full_solutions(FULL_SOLUTIONS_FILENAME, library, K, Q, V, A)
@@ -878,103 +881,164 @@ def check_key_distances(K):
 
 ######################################################################
 ######################################################################
+def write_one_student_exam(out_f,ei,library,flat_questions, K, Q, V, A, one_page_per_q):
+  """write_one_student_exam(out_f,ei,library,flat_questions, K, Q, V, A, one_page_per_q)
+  Writes one student exam to the output stream out_f
+  """
+  (N_e, N_Q, N_A) = A.shape
+  out_f.write(("%" * 70 + "\n") * 4)
+  out_f.write(r"\cleardoublepage" + "\n")
+  out_f.write(r"%% Exam number %d" % (ei + 1) + "\n\n")
+  out_f.write(r"\examnumber=%d" % (ei + 1) + "\n\n")
+      
+  out_f.write(r"\message{Exam %d/%d}" % (ei + 1, N_e) + "\n")
+  out_f.write(r"\setcounter{page}{1}" + "\n\n")
+  out_f.write(library.coverpage + "\n")
+  out_f.write(r"\begin{enumerate}" + "\n")
+  for (i_key_digit, key_digit) in enumerate(K[ei]):
+      key_question = LAST_SCANTRON_QUESTION_NUMBER - len(K[ei]) + i_key_digit + 1
+      out_f.write(r"\item[%d.] %s" % (key_question, key_digit) + "\n")
+  out_f.write(r"\end{enumerate}" + "\n\n")
+  out_f.write(r"\newpage" + "\n\n")
 
-def write_exams(output_filename, library, K, Q, V, A, min_pages, one_page_per_q):
-    """write_exams(output_filename, library, K, Q, V, A, min_pages, one_page_per_q)
+  qi = 0
+  for (i_zone, zone) in enumerate(library.zones):
+      out_f.write("%% Zone %d\n\n" % (i_zone + 1))
+      out_f.write(zone.body + "\n\n")
+      for i_zone_question in range(len(zone.questions)):
+          if one_page_per_q:
+              out_f.write(r"\newpage" + "\n")
+          out_f.write(r"\noindent" + "\n")
+          if not one_page_per_q:
+              out_f.write(r"\begin{minipage}{\textwidth}" + "\n")
+          points = flat_questions[Q[ei,qi]].points
+          out_f.write(r"%d. (%g %s)" % (qi + 1, points,
+                                        "point" if points == 1 else "points")
+                      + "\n")
+          variant = flat_questions[Q[ei,qi]].variants[V[ei,qi]]
+          out_f.write(variant.body + "\n")
+          n_answers = len([ai for ai in range(N_A) if chr2ind(A[ei,qi,ai]) >= 0])
+          if n_answers > 0:
+              #For less whitespace: out_f.write(r"\begin{enumerate}[topsep=4pt,itemsep=1pt,partopsep=1pt,parsep=1pt]" + "\n")
+              out_f.write(r"\begin{enumerate}" + "\n")
+              for ai in range(N_A):
+                  Ai = chr2ind(A[ei,qi,ai])
+                  if Ai >= 0:
+                      out_f.write(r"\item[(%s)]" % ind2chr(ai) + "\n")
+                      out_f.write(variant.answers[Ai].body + "\n")
+              out_f.write(r"\end{enumerate}" + "\n")
+          if not one_page_per_q:
+              out_f.write(r"\vspace*{10em}" + "\n")
+              # For less whitespace: 0.5em
+              out_f.write(r"\end{minipage}" + "\n")
+              out_f.write(r"\filbreak\vfil\penalty-200\vfilneg" + "\n\n")
 
-    Write the generated exams to the exams.tex file, padding each exam
+          qi += 1
+
+######################################################################
+######################################################################
+
+def write_exams(output_directory,base_filename, separate_files,library, K, Q, V, A, min_pages, one_page_per_q):
+    """write_exams(output_directory,base_filename, library, K, Q, V, A, min_pages, one_page_per_q)
+
+    If separate_files is false: Write the generated exams to the single file, padding each exam
     to be at least min_pages long and an even number of pages.
-    """
-    log_and_print("Writing randomized exams to file: %s" % output_filename)
+    
+    If separate_files is true: Write the generate exams to the given directory (one tex file per student id).
+    Each tex file can be a different number of pages.
+    """    
+    if not os.path.exists(output_directory):
+        os.makedirs(output_directory)
+        
+    output_filename = os.path.join(output_directory, base_filename )
+    
+    log_and_print("Writing randomized exams : %s" % output_filename)
     (N_e, N_Q, N_A) = A.shape
 
     flat_questions = list(itertools.chain.from_iterable([zone.questions for zone in library.zones]))
-    with open(output_filename, "w") as out_f:
-        out_f.write(library.preamble + "\n")
-        out_f.write("\n")
-        out_f.write(r"\begin{document}" + "\n")
-        out_f.write("\n")
-        out_f.write(r"\newcount\maxrawpages" + "\n")
-        out_f.write(r"\newcount\maxpadpages" + "\n")
-        out_f.write(r"\newcount\minpadpages" + "\n")
-        out_f.write(r"\maxrawpages=0" + "\n")
-        out_f.write(r"\maxpadpages=0" + "\n")
-        out_f.write(r"\minpadpages=1000000" + "\n")
-        out_f.write(r"\newcount\padcount" + "\n")
-        out_f.write("\n")
 
-        for ei in range(N_e):
-            out_f.write(("%" * 70 + "\n") * 4)
-            out_f.write(r"\cleardoublepage" + "\n")
-            out_f.write(r"%% Exam number %d" % (ei + 1) + "\n\n")
-            out_f.write(r"\message{Exam %d/%d}" % (ei + 1, N_e) + "\n")
-            out_f.write(r"\setcounter{page}{1}" + "\n\n")
-            out_f.write(library.coverpage + "\n")
-            out_f.write(r"\begin{enumerate}" + "\n")
-            for (i_key_digit, key_digit) in enumerate(K[ei]):
-                key_question = LAST_SCANTRON_QUESTION_NUMBER - len(K[ei]) + i_key_digit + 1
-                out_f.write(r"\item[%d.] %s" % (key_question, key_digit) + "\n")
-            out_f.write(r"\end{enumerate}" + "\n\n")
-            out_f.write(r"\newpage" + "\n\n")
+    #Todo: This code would be tidier if we assigned the numerous output lines to strings first . 
+    #Then you could see the iteration logic below compressed into 10 lines instead of 100
+    
+    for ei in range(N_e):
+      if separate_files :
+          # exam.tex -> exam_1.tex
+          output_filename_full = ("_"+str(ei+1)+".").join( output_filename.rsplit(".") )
 
-            qi = 0
-            for (i_zone, zone) in enumerate(library.zones):
-                out_f.write("%% Zone %d\n\n" % (i_zone + 1))
-                out_f.write(zone.body + "\n\n")
-                for i_zone_question in range(len(zone.questions)):
-                    if one_page_per_q:
-                        out_f.write(r"\newpage" + "\n")
-                    out_f.write(r"\noindent" + "\n")
-                    if not one_page_per_q:
-                        out_f.write(r"\begin{minipage}{\textwidth}" + "\n")
-                    points = flat_questions[Q[ei,qi]].points
-                    out_f.write(r"%d. (%g %s)" % (qi + 1, points,
-                                                  "point" if points == 1 else "points")
-                                + "\n")
-                    variant = flat_questions[Q[ei,qi]].variants[V[ei,qi]]
-                    out_f.write(variant.body + "\n")
-                    n_answers = len([ai for ai in range(N_A) if chr2ind(A[ei,qi,ai]) >= 0])
-                    if n_answers > 0:
-                        out_f.write(r"\begin{enumerate}" + "\n")
-                        for ai in range(N_A):
-                            Ai = chr2ind(A[ei,qi,ai])
-                            if Ai >= 0:
-                                out_f.write(r"\item[(%s)]" % ind2chr(ai) + "\n")
-                                out_f.write(variant.answers[Ai].body + "\n")
-                        out_f.write(r"\end{enumerate}" + "\n")
-                    if not one_page_per_q:
-                        out_f.write(r"\vspace*{10em}" + "\n")
-                        out_f.write(r"\end{minipage}" + "\n")
-                        out_f.write(r"\filbreak\vfil\penalty-200\vfilneg" + "\n\n")
+      elif ei == 0 :
+          output_filename_full = output_filename
+      
+      if(output_filename_full) :
+          out_f = open( output_filename_full ,"w")
+          output_filename_full = ""
+          
+          out_f.write(library.preamble + "\n\n")
 
-                    qi += 1
+          out_f.write(r"\begin{document}" + "\n")
+          out_f.write("\n")
+          
+          out_f.write(r"\newcount\examnumber" + "\n") # set in write_one_student_exam
+          out_f.write(r"\newcount\questioncountall" + "\n")
+          out_f.write(r"\questioncountall=%d" % len(flat_questions))
+          out_f.write("\n")
+                    
+# Can't declare Tex variables with numbers in , perhaps someone will continue to develop this...
+#          for (i_zone, zone) in enumerate(library.zones):  
+#              out_f.write(r"\newcount\questioncountzone%d" % (i_zone + 1) )
+#              out_f.write("\n")
+#              out_f.write(r"\questioncountzone%d=%d" % ( i_zone + 1 ,len(zone.questions) ))
+#              out_f.write("\n") 
 
-            out_f.write("\n")
-            out_f.write(r"\ifnum\maxrawpages<\thepage \maxrawpages=\thepage\fi" + "\n")
-            out_f.write("\n")
-            out_f.write(r"\ifnum\thepage<%d" % min_pages + "\n")
-            out_f.write(r"\padcount=\thepage" + "\n")
-            out_f.write(r"\loop" + "\n")
-            out_f.write(r"\newpage \ \par \vspace*{\fill}\centerline{This page is intentionally left blank.}\vspace*{\fill}" + "\n")
-            out_f.write(r"\advance \padcount 1" + "\n")
-            out_f.write(r"\ifnum \padcount<%d" % min_pages + "\n")
-            out_f.write(r"\repeat" + "\n")
-            out_f.write(r"\fi" + "\n")
-            out_f.write("\n")
-            out_f.write(r"\ifnum\maxpadpages<\thepage \maxpadpages=\thepage\fi" + "\n")
-            out_f.write("\n")
-            out_f.write(r"\ifnum\minpadpages>\thepage \minpadpages=\thepage\fi" + "\n")
-            out_f.write("\n")
+          out_f.write(r"\newcount\maxrawpages" + "\n")
+          out_f.write(r"\newcount\maxpadpages" + "\n")
+          out_f.write(r"\newcount\minpadpages" + "\n")          
+          out_f.write(r"\maxrawpages=0" + "\n")
+          out_f.write(r"\maxpadpages=0" + "\n")
+          out_f.write(r"\minpadpages=1000000" + "\n")
+          out_f.write(r"\newcount\padcount" + "\n")
 
-        out_f.write("\n")
-        out_f.write(r"\cleardoublepage" + "\n")
-        out_f.write(r"\message{Max raw (unpadded) length: \the\maxrawpages.}" + "\n")
-        out_f.write(r"\message{Max padded length: \the\maxpadpages.}" + "\n")
-        out_f.write(r"\message{Min padded length: \the\minpadpages.}" + "\n")
-        out_f.write(r"\ifnum\maxpadpages>\minpadpages \message{WARNING: exams are not all the same length.}" + "\n")
-        out_f.write(r"\else\message{Exams are all the same length.}\fi" + "\n")
-        out_f.write("\n")
+          
+          
+        
+      write_one_student_exam(out_f,ei,library,flat_questions, K, Q, V, A, one_page_per_q)
+                
+
+      out_f.write("\n")
+      if(separate_files) :
         out_f.write(r"\end{document}" + "\n")
+        out_f.close()
+        out_f = None
+      else:  
+        # Ensure all exams are even in length and have padding pages if necessary
+        out_f.write(r"\ifnum\maxrawpages<\thepage \maxrawpages=\thepage\fi" + "\n")
+        out_f.write("\n")
+        out_f.write(r"\ifnum\thepage<%d" % min_pages + "\n")
+        out_f.write(r"\padcount=\thepage" + "\n")
+        out_f.write(r"\loop" + "\n")
+        out_f.write(r"\newpage \ \par \vspace*{\fill}\centerline{This page is intentionally left blank.}\vspace*{\fill}" + "\n")
+        out_f.write(r"\advance \padcount 1" + "\n")
+        out_f.write(r"\ifnum \padcount<%d" % min_pages + "\n")
+        out_f.write(r"\repeat" + "\n")
+        out_f.write(r"\fi" + "\n")
+        out_f.write("\n")
+        out_f.write(r"\ifnum\maxpadpages<\thepage \maxpadpages=\thepage\fi" + "\n")
+        out_f.write("\n")
+        out_f.write(r"\ifnum\minpadpages>\thepage \minpadpages=\thepage\fi" + "\n")
+        out_f.write("\n")
+
+    if(not(separate_files)) :
+      out_f.write("\n")
+      out_f.write(r"\cleardoublepage" + "\n")
+      out_f.write(r"\message{Max raw (unpadded) length: \the\maxrawpages.}" + "\n")
+      out_f.write(r"\message{Max padded length: \the\maxpadpages.}" + "\n")
+      out_f.write(r"\message{Min padded length: \the\minpadpages.}" + "\n")
+      out_f.write(r"\ifnum\maxpadpages>\minpadpages \message{WARNING: exams are not all the same length.}" + "\n")
+      out_f.write(r"\else\message{Exams are all the same length.}\fi" + "\n")
+      out_f.write("\n")
+      out_f.write(r"\end{document}" + "\n")
+      out_f.close()
+      out_f = None
+      
     log("Successfully completed writing randomized exams")
 
 ######################################################################

--- a/separate-files-readme.txt
+++ b/separate-files-readme.txt
@@ -1,0 +1,77 @@
+This version of randexam has a new option
+MULTIPLE_EXAM_FILES
+This is initially false, so randexam proc-lib will still generate a single massive exam.tex (but now in a subdirectory 'print')
+
+Setting this option to true will generate a single .tex file per exam
+
+The rest of this readme discusses a couple of ways I generate pdfs and print all of these pdfs.
+I have not yet created python code for these tasks.
+
+I've used two ways to generate the pdfs:
+1. A simple shell script
+2. A Makefile (that is faster when you have 400 exams to convert)
+
+
+1. Shell script:
+
+#!/bin/bash
+cd print
+for i in *.tex; do /usr/texbin/pdflatex $i;done
+
+2. Makefile:
+
+The following Makefile is great because make can do jobs in parallel.
+e.g. If you have 8CPU machine:
+
+> cd print
+> make -j8     # Run 8 jobs in parallel
+
+
+
+SOURCES=$(wildcard *tex)
+EXAM_PDF_FILES=$(SOURCES:.tex=.pdf)
+
+all: $(EXAM_PDF_FILES)
+
+#Remember! Makefiles require the commands to be indented with a tab not a space
+
+%.pdf : %.tex
+	rm -f $@ 
+	pdflatex  $< 
+
+
+
+----
+Printing
+So now you need a way to print all of these to a printer or two.
+Enter CUPS. You'll need to learn how to set the printer-specific options to enable/disable stapling and double-sided.
+This is what worked on my Mac that already had a printer queue name '_1228' defined to a printer in room 1228:
+First, find out your printer queue and its option:
+
+lpstat -p    # list printer queues
+printer _1228 is idle.
+printer _2203 is idle.
+
+Get a big list of printer options for your printer of choice (-l is important):
+lpoptions -p _1228 -l
+
+Duplex/2-Sided Printing: None *DuplexNoTumble DuplexTumble
+XRXStapling/Stapling: *None Front Dual Rear
+... other options
+
+Each line shows the short key, description and possible values. The default value is shown with an *
+Now we can use this to set the output. Here's a script that works for me (on a Mac)
+
+#!/bin/bash
+#Typical duplex options for Siebel printers:  Duplex=DuplexNoTumble Duplex=None
+EXAMPREFIX=cs241_02_cfork_exams
+#Example: Print out the first  200 exams (#1 to #200):
+for i in `seq 1 200` ; do 
+  echo $i ;
+  lpr -P _1228 -o  XRXStapling=Front -o Duplex=DuplexNoTumble ${EXAMPREFIX}_${i}.pdf
+done
+
+
+
+
+


### PR DESCRIPTION
The separate files commit also creates a couple of Tex counters questioncountall and examnumber that can be displayed in the tex. In theory it could also create counts for each zone (so you could print "28 Multiple Choice and 6 Long answer) but I ran out of time to investigate how to do this best in Tex.

pdf generation and printing is not implemented in python - sorry - perhaps you'd like to add this. However I do include some notes and a few examples on how to do this on a Mac using very simple shell script or Makefile.

The email task now renames the pdf file after it has sent it (netid.pdf -> sent-netid.pdf). This ensures the email-task can be restarted and will skip students that have already been emailed.
